### PR TITLE
feat: paper trading ledger and analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Backtesting exchange so you can try your trading strategies before using real funds.
 * Live trading at [Binance](https://www.binance.com/), [Bitstamp](https://www.bitstamp.net/) and [Hyperliquid](https://hyperliquid.xyz/) crypto currency exchanges.
 * Portfolio-level risk management with configurable limits (max positions, exposure caps, correlation buckets, daily loss caps, kill switch).
+* Paper trading ledger with trade journal, equity curve tracking, and performance analytics (Sharpe, Sortino, Calmar, drawdown, profit factor).
 * Asynchronous I/O and event driven.
 
 ## Getting Started

--- a/basana/core/ledger/__init__.py
+++ b/basana/core/ledger/__init__.py
@@ -1,0 +1,30 @@
+# Basana
+#
+# Copyright 2026 Christian Pojoni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: F401
+
+from basana.core.ledger.ledger import TradingLedger
+from basana.core.ledger.metrics import (
+    calculate_max_drawdown,
+    calculate_metrics,
+    calculate_sharpe_ratio,
+    calculate_sortino_ratio,
+)
+from basana.core.ledger.types import (
+    EquitySnapshot,
+    PerformanceMetrics,
+    TradeRecord,
+)

--- a/basana/core/ledger/ledger.py
+++ b/basana/core/ledger/ledger.py
@@ -1,0 +1,238 @@
+# Basana
+#
+# Copyright 2026 Christian Pojoni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+from typing import Dict, List, Optional, Sequence
+import collections
+import datetime
+import logging
+import uuid
+
+from basana.core import dt, logs
+from basana.core.pair import Pair
+from basana.core.ledger.metrics import calculate_metrics
+from basana.core.ledger.types import EquitySnapshot, PerformanceMetrics, TradeRecord
+
+
+logger = logging.getLogger(__name__)
+
+
+class _OpenPosition:
+    def __init__(self, pair: Pair, signed_qty: Decimal, entry_price: Decimal, entry_dt: datetime.datetime):
+        self.pair = pair
+        self.signed_qty = signed_qty
+        self.avg_entry_price = entry_price
+        self.entry_dt = entry_dt
+        self.current_price = entry_price
+
+    @property
+    def unrealized_pnl(self) -> Decimal:
+        return (self.current_price - self.avg_entry_price) * self.signed_qty
+
+    @property
+    def notional(self) -> Decimal:
+        return abs(self.signed_qty * self.current_price)
+
+
+class TradingLedger:
+    """Paper trading ledger that records fills, tracks equity, and produces analytics.
+
+    :param initial_cash: Starting cash balance in quote currency.
+    :param equity_snapshot_interval: Minimum time between automatic equity snapshots.
+        If ``None``, snapshots are only taken when explicitly requested or on fills.
+    """
+
+    def __init__(
+        self,
+        initial_cash: Decimal = Decimal(0),
+        equity_snapshot_interval: Optional[datetime.timedelta] = None,
+    ):
+        self._initial_cash = initial_cash
+        self._cash = initial_cash
+        self._positions: Dict[Pair, _OpenPosition] = {}
+        self._trades: List[TradeRecord] = []
+        self._equity_curve: List[EquitySnapshot] = []
+        self._snapshot_interval = equity_snapshot_interval
+        self._last_snapshot_dt: Optional[datetime.datetime] = None
+        self._daily_pnl: Dict[datetime.date, Decimal] = collections.defaultdict(Decimal)
+        self._weekly_pnl: Dict[str, Decimal] = collections.defaultdict(Decimal)  # ISO week key
+
+    def record_fill(
+        self,
+        pair: Pair,
+        signed_qty: Decimal,
+        fill_price: Decimal,
+        when: datetime.datetime,
+        reason: Optional[str] = None,
+    ) -> Optional[TradeRecord]:
+        """Record an order fill. Returns a TradeRecord if a position was closed/reduced.
+
+        :param pair: The trading pair.
+        :param signed_qty: Signed fill quantity (positive = buy, negative = sell).
+        :param fill_price: The fill price.
+        :param when: Fill datetime (timezone-aware).
+        :param reason: Optional reason code for the trade.
+        :returns: A :class:`TradeRecord` if a position was closed or reduced, else None.
+        """
+        assert not dt.is_naive(when), f"{when} should have timezone information set"
+
+        trade_record = None
+        pos = self._positions.get(pair)
+
+        if pos is None:
+            # Opening a new position.
+            self._positions[pair] = _OpenPosition(pair, signed_qty, fill_price, when)
+        elif pos.signed_qty * signed_qty > 0:
+            # Adding to the same side.
+            total_cost = abs(pos.signed_qty) * pos.avg_entry_price + abs(signed_qty) * fill_price
+            pos.signed_qty += signed_qty
+            pos.avg_entry_price = total_cost / abs(pos.signed_qty)
+        else:
+            # Reducing or closing or flipping.
+            closed_qty = min(abs(signed_qty), abs(pos.signed_qty))
+            if pos.signed_qty > 0:
+                realized = (fill_price - pos.avg_entry_price) * closed_qty
+            else:
+                realized = (pos.avg_entry_price - fill_price) * closed_qty
+
+            entry_cost = pos.avg_entry_price * closed_qty
+            return_pct = realized / entry_cost if entry_cost != 0 else Decimal(0)
+
+            trade_record = TradeRecord(
+                trade_id=uuid.uuid4().hex[:12],
+                pair=pair,
+                entry_dt=pos.entry_dt,
+                exit_dt=when,
+                signed_qty=pos.signed_qty if closed_qty == abs(pos.signed_qty) else (
+                    Decimal(closed_qty) if pos.signed_qty > 0 else Decimal(-closed_qty)
+                ),
+                entry_price=pos.avg_entry_price,
+                exit_price=fill_price,
+                realized_pnl=realized,
+                return_pct=return_pct,
+                reason=reason,
+            )
+            self._trades.append(trade_record)
+            self._cash += realized
+
+            # Track daily/weekly P&L.
+            trade_date = when.date()
+            self._daily_pnl[trade_date] += realized
+            iso_year, iso_week, _ = trade_date.isocalendar()
+            self._weekly_pnl[f"{iso_year}-W{iso_week:02d}"] += realized
+
+            logger.debug(
+                logs.StructuredMessage(
+                    "Trade closed",
+                    pair=str(pair),
+                    pnl=str(realized),
+                    return_pct=f"{return_pct:.4f}",
+                    reason=reason,
+                )
+            )
+
+            new_qty = pos.signed_qty + signed_qty
+            if new_qty == Decimal(0):
+                del self._positions[pair]
+            elif pos.signed_qty * new_qty < 0:
+                # Flipped sides.
+                self._positions[pair] = _OpenPosition(pair, new_qty, fill_price, when)
+            else:
+                pos.signed_qty = new_qty
+
+        # Update price and take snapshot.
+        if pair in self._positions:
+            self._positions[pair].current_price = fill_price
+        self._maybe_snapshot(when)
+
+        return trade_record
+
+    def update_price(self, pair: Pair, price: Decimal, when: Optional[datetime.datetime] = None) -> None:
+        """Update the market price for a pair.
+
+        :param pair: The trading pair.
+        :param price: The current market price.
+        :param when: Optional datetime for triggering equity snapshots.
+        """
+        pos = self._positions.get(pair)
+        if pos is not None:
+            pos.current_price = price
+        if when is not None:
+            self._maybe_snapshot(when)
+
+    def take_snapshot(self, when: datetime.datetime) -> EquitySnapshot:
+        """Take an equity snapshot at the given time.
+
+        :param when: The snapshot datetime (timezone-aware).
+        :returns: The equity snapshot.
+        """
+        assert not dt.is_naive(when), f"{when} should have timezone information set"
+
+        equity = self._cash + sum((p.unrealized_pnl for p in self._positions.values()), Decimal(0))
+        snap = EquitySnapshot(when=when, equity=equity)
+        self._equity_curve.append(snap)
+        self._last_snapshot_dt = when
+        return snap
+
+    @property
+    def trades(self) -> Sequence[TradeRecord]:
+        """All completed trade records."""
+        return self._trades
+
+    @property
+    def equity_curve(self) -> Sequence[EquitySnapshot]:
+        """All equity snapshots taken so far."""
+        return self._equity_curve
+
+    @property
+    def cash(self) -> Decimal:
+        """Current cash balance."""
+        return self._cash
+
+    @property
+    def open_positions(self) -> Dict[Pair, Decimal]:
+        """Current open positions as {pair: signed_qty}."""
+        return {pair: pos.signed_qty for pair, pos in self._positions.items()}
+
+    def get_equity(self) -> Decimal:
+        """Current total equity (cash + unrealized P&L)."""
+        return self._cash + sum((p.unrealized_pnl for p in self._positions.values()), Decimal(0))
+
+    def get_unrealized_pnl(self) -> Decimal:
+        """Total unrealized P&L across all open positions."""
+        return sum((p.unrealized_pnl for p in self._positions.values()), Decimal(0))
+
+    def get_daily_pnl(self) -> Dict[datetime.date, Decimal]:
+        """Realized P&L by date."""
+        return dict(self._daily_pnl)
+
+    def get_weekly_pnl(self) -> Dict[str, Decimal]:
+        """Realized P&L by ISO week (e.g. '2026-W01')."""
+        return dict(self._weekly_pnl)
+
+    def calculate_metrics(self, periods_per_year: int = 252) -> PerformanceMetrics:
+        """Calculate performance metrics from all recorded trades and equity curve.
+
+        :param periods_per_year: Number of periods per year for annualization.
+        :returns: A :class:`PerformanceMetrics` instance.
+        """
+        return calculate_metrics(self._trades, self._equity_curve, periods_per_year)
+
+    def _maybe_snapshot(self, when: datetime.datetime) -> None:
+        if self._snapshot_interval is None:
+            return
+        if self._last_snapshot_dt is None or (when - self._last_snapshot_dt) >= self._snapshot_interval:
+            self.take_snapshot(when)

--- a/basana/core/ledger/ledger.py
+++ b/basana/core/ledger/ledger.py
@@ -42,10 +42,6 @@ class _OpenPosition:
     def unrealized_pnl(self) -> Decimal:
         return (self.current_price - self.avg_entry_price) * self.signed_qty
 
-    @property
-    def notional(self) -> Decimal:
-        return abs(self.signed_qty * self.current_price)
-
 
 class TradingLedger:
     """Paper trading ledger that records fills, tracks equity, and produces analytics.

--- a/basana/core/ledger/metrics.py
+++ b/basana/core/ledger/metrics.py
@@ -1,0 +1,208 @@
+# Basana
+#
+# Copyright 2026 Christian Pojoni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+from typing import Any, Iterable, List, Optional, Sequence
+import math
+
+from basana.core.ledger.types import EquitySnapshot, PerformanceMetrics, TradeRecord
+
+_ZERO = Decimal(0)
+
+
+def calculate_max_drawdown(equity_curve: Sequence[EquitySnapshot]) -> Decimal:
+    """Calculate maximum drawdown from an equity curve.
+
+    :param equity_curve: Chronologically ordered equity snapshots.
+    :returns: Maximum drawdown as a positive fraction (e.g. 0.20 = 20% drawdown).
+    """
+    if len(equity_curve) < 2:
+        return _ZERO
+
+    peak = equity_curve[0].equity
+    max_dd = _ZERO
+
+    for snap in equity_curve[1:]:
+        if snap.equity > peak:
+            peak = snap.equity
+        if peak > 0:
+            dd = (peak - snap.equity) / peak
+            if dd > max_dd:
+                max_dd = dd
+
+    return max_dd
+
+
+def calculate_sharpe_ratio(
+    equity_curve: Sequence[EquitySnapshot],
+    risk_free_rate: Decimal = _ZERO,
+    periods_per_year: int = 252,
+) -> Optional[Decimal]:
+    """Calculate annualized Sharpe ratio from equity curve returns.
+
+    :param equity_curve: Chronologically ordered equity snapshots.
+    :param risk_free_rate: Annualized risk-free rate as a decimal.
+    :param periods_per_year: Number of periods per year for annualization.
+    :returns: Annualized Sharpe ratio, or None if insufficient data.
+    """
+    returns = _calculate_returns(equity_curve)
+    if len(returns) < 2:
+        return None
+
+    n = Decimal(len(returns))
+    avg_return = _sum(returns) / n
+    period_rf = risk_free_rate / Decimal(periods_per_year)
+    excess_returns = [r - period_rf for r in returns]
+    avg_excess = _sum(excess_returns) / n
+
+    variance = _sum((r - avg_return) ** 2 for r in returns) / (n - Decimal(1))
+    std_dev = Decimal(str(math.sqrt(float(variance))))
+
+    if std_dev == _ZERO:
+        return None
+
+    return (avg_excess / std_dev) * Decimal(str(math.sqrt(periods_per_year)))
+
+
+def calculate_sortino_ratio(
+    equity_curve: Sequence[EquitySnapshot],
+    risk_free_rate: Decimal = _ZERO,
+    periods_per_year: int = 252,
+) -> Optional[Decimal]:
+    """Calculate annualized Sortino ratio from equity curve returns.
+
+    :param equity_curve: Chronologically ordered equity snapshots.
+    :param risk_free_rate: Annualized risk-free rate as a decimal.
+    :param periods_per_year: Number of periods per year for annualization.
+    :returns: Annualized Sortino ratio, or None if insufficient data.
+    """
+    returns = _calculate_returns(equity_curve)
+    if len(returns) < 2:
+        return None
+
+    n = Decimal(len(returns))
+    period_rf = risk_free_rate / Decimal(periods_per_year)
+    excess_returns = [r - period_rf for r in returns]
+    avg_excess = _sum(excess_returns) / n
+
+    downside = [r for r in returns if r < 0]
+    if not downside:
+        return None
+
+    downside_variance = _sum(r ** 2 for r in downside) / n
+    downside_dev = Decimal(str(math.sqrt(float(downside_variance))))
+
+    if downside_dev == _ZERO:
+        return None
+
+    return (avg_excess / downside_dev) * Decimal(str(math.sqrt(periods_per_year)))
+
+
+def calculate_metrics(
+    trades: Sequence[TradeRecord],
+    equity_curve: Sequence[EquitySnapshot],
+    periods_per_year: int = 252,
+) -> PerformanceMetrics:
+    """Calculate comprehensive performance metrics.
+
+    :param trades: List of completed trade records.
+    :param equity_curve: Chronologically ordered equity snapshots.
+    :param periods_per_year: Number of periods per year for annualization.
+    :returns: A :class:`PerformanceMetrics` instance.
+    """
+    total_trades = len(trades)
+    if total_trades == 0:
+        return PerformanceMetrics(
+            total_trades=0,
+            winning_trades=0,
+            losing_trades=0,
+            win_rate=_ZERO,
+            total_pnl=_ZERO,
+            avg_pnl=_ZERO,
+            profit_factor=None,
+            expectancy=_ZERO,
+            max_drawdown=_ZERO,
+            sharpe_ratio=None,
+            sortino_ratio=None,
+            calmar_ratio=None,
+            avg_win=_ZERO,
+            avg_loss=_ZERO,
+        )
+
+    winners = [t for t in trades if t.realized_pnl > 0]
+    losers = [t for t in trades if t.realized_pnl < 0]
+    winning_trades = len(winners)
+    losing_trades = len(losers)
+
+    total_pnl = _sum(t.realized_pnl for t in trades)
+    avg_pnl = total_pnl / Decimal(total_trades)
+    win_rate = Decimal(winning_trades) / Decimal(total_trades)
+
+    gross_profit = _sum(t.realized_pnl for t in winners)
+    gross_loss = abs(_sum(t.realized_pnl for t in losers))
+
+    profit_factor: Optional[Decimal] = None
+    if gross_loss > 0:
+        profit_factor = gross_profit / gross_loss
+
+    avg_win = gross_profit / Decimal(winning_trades) if winning_trades > 0 else _ZERO
+    avg_loss = gross_loss / Decimal(losing_trades) if losing_trades > 0 else _ZERO
+    loss_rate = Decimal(1) - win_rate
+    expectancy = avg_win * win_rate - avg_loss * loss_rate
+
+    max_dd = calculate_max_drawdown(equity_curve)
+    sharpe = calculate_sharpe_ratio(equity_curve, periods_per_year=periods_per_year)
+    sortino = calculate_sortino_ratio(equity_curve, periods_per_year=periods_per_year)
+
+    calmar: Optional[Decimal] = None
+    if max_dd > 0 and len(equity_curve) >= 2:
+        total_return = (equity_curve[-1].equity - equity_curve[0].equity) / equity_curve[0].equity
+        n_periods = Decimal(len(equity_curve) - 1)
+        if n_periods > 0:
+            annualized_return = total_return * Decimal(periods_per_year) / n_periods
+            calmar = annualized_return / max_dd
+
+    return PerformanceMetrics(
+        total_trades=total_trades,
+        winning_trades=winning_trades,
+        losing_trades=losing_trades,
+        win_rate=win_rate,
+        total_pnl=total_pnl,
+        avg_pnl=avg_pnl,
+        profit_factor=profit_factor,
+        expectancy=expectancy,
+        max_drawdown=max_dd,
+        sharpe_ratio=sharpe,
+        sortino_ratio=sortino,
+        calmar_ratio=calmar,
+        avg_win=avg_win,
+        avg_loss=avg_loss,
+    )
+
+
+def _sum(values: Iterable[Any]) -> Decimal:
+    """Sum Decimal values with Decimal(0) as start to avoid int return type."""
+    return sum(values, _ZERO)
+
+
+def _calculate_returns(equity_curve: Sequence[EquitySnapshot]) -> List[Decimal]:
+    """Calculate period-over-period returns from an equity curve."""
+    returns: List[Decimal] = []
+    for i in range(1, len(equity_curve)):
+        prev = equity_curve[i - 1].equity
+        if prev != 0:
+            returns.append((equity_curve[i].equity - prev) / prev)
+    return returns

--- a/basana/core/ledger/metrics.py
+++ b/basana/core/ledger/metrics.py
@@ -105,7 +105,7 @@ def calculate_sortino_ratio(
     downside_variance = _sum(r ** 2 for r in downside) / n
     downside_dev = Decimal(str(math.sqrt(float(downside_variance))))
 
-    if downside_dev == _ZERO:
+    if downside_dev == _ZERO:  # pragma: no cover
         return None
 
     return (avg_excess / downside_dev) * Decimal(str(math.sqrt(periods_per_year)))

--- a/basana/core/ledger/types.py
+++ b/basana/core/ledger/types.py
@@ -1,0 +1,92 @@
+# Basana
+#
+# Copyright 2026 Christian Pojoni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+from typing import Optional
+import dataclasses
+import datetime
+
+from basana.core.pair import Pair
+
+
+@dataclasses.dataclass(frozen=True)
+class TradeRecord:
+    """An immutable record of a completed trade (round-trip or partial)."""
+
+    #: Unique trade ID.
+    trade_id: str
+    #: The trading pair.
+    pair: Pair
+    #: Entry datetime.
+    entry_dt: datetime.datetime
+    #: Exit datetime.
+    exit_dt: datetime.datetime
+    #: Signed entry quantity (positive = long, negative = short).
+    signed_qty: Decimal
+    #: Entry price.
+    entry_price: Decimal
+    #: Exit price.
+    exit_price: Decimal
+    #: Realized P&L in quote currency.
+    realized_pnl: Decimal
+    #: Return as a fraction (e.g. 0.05 = 5%).
+    return_pct: Decimal
+    #: Optional reason code for the trade (e.g. "signal", "stop_loss", "take_profit", "time_exit").
+    reason: Optional[str] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class EquitySnapshot:
+    """A point-in-time equity measurement."""
+
+    #: When this snapshot was taken.
+    when: datetime.datetime
+    #: Total equity (cash + unrealized P&L).
+    equity: Decimal
+
+
+@dataclasses.dataclass(frozen=True)
+class PerformanceMetrics:
+    """Calculated performance metrics over a period."""
+
+    #: Total number of trades.
+    total_trades: int
+    #: Number of winning trades.
+    winning_trades: int
+    #: Number of losing trades.
+    losing_trades: int
+    #: Win rate as a fraction (0-1).
+    win_rate: Decimal
+    #: Total realized P&L.
+    total_pnl: Decimal
+    #: Average P&L per trade.
+    avg_pnl: Decimal
+    #: Profit factor (gross profit / gross loss). None if no losses.
+    profit_factor: Optional[Decimal]
+    #: Expectancy (avg_win * win_rate - avg_loss * loss_rate).
+    expectancy: Decimal
+    #: Maximum drawdown as a fraction (0-1).
+    max_drawdown: Decimal
+    #: Annualized Sharpe ratio. None if insufficient data.
+    sharpe_ratio: Optional[Decimal]
+    #: Annualized Sortino ratio. None if insufficient data.
+    sortino_ratio: Optional[Decimal]
+    #: Calmar ratio (annualized return / max drawdown). None if max drawdown is zero.
+    calmar_ratio: Optional[Decimal]
+    #: Average winning trade P&L.
+    avg_win: Decimal
+    #: Average losing trade P&L.
+    avg_loss: Decimal

--- a/tests/test_backtesting_exchange_loans.py
+++ b/tests/test_backtesting_exchange_loans.py
@@ -196,7 +196,7 @@ def test_borrow_and_repay(
         assert loan.borrowed_amount == loan_amount
 
         # Time to repay. Move clock if necessary.
-        backtesting_dispatcher._set_now(dt.local_now())
+        backtesting_dispatcher._set_now(now)
         if repay_after:
             backtesting_dispatcher._set_now(backtesting_dispatcher.now() + repay_after)
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,420 @@
+# Basana
+#
+# Copyright 2026 Christian Pojoni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+import datetime
+
+from dateutil import tz
+
+import basana as bs
+from basana.core.ledger import (
+    EquitySnapshot,
+    PerformanceMetrics,
+    TradingLedger,
+    TradeRecord,
+    calculate_max_drawdown,
+    calculate_metrics,
+    calculate_sharpe_ratio,
+    calculate_sortino_ratio,
+)
+
+utc = tz.UTC
+btc_pair = bs.Pair("BTC", "USD")
+eth_pair = bs.Pair("ETH", "USD")
+
+
+def _dt(day=1, hour=12, minute=0):
+    return datetime.datetime(2026, 1, day, hour, minute, 0, tzinfo=utc)
+
+
+# --- TradeRecord tests ---
+
+
+def test_trade_record_frozen():
+    tr = TradeRecord(
+        trade_id="abc",
+        pair=btc_pair,
+        entry_dt=_dt(1),
+        exit_dt=_dt(2),
+        signed_qty=Decimal("1"),
+        entry_price=Decimal("50000"),
+        exit_price=Decimal("55000"),
+        realized_pnl=Decimal("5000"),
+        return_pct=Decimal("0.1"),
+        reason="signal",
+    )
+    try:
+        tr.realized_pnl = Decimal(0)  # type: ignore[misc]
+        assert False, "Should have raised"
+    except AttributeError:
+        pass
+
+
+def test_equity_snapshot_frozen():
+    snap = EquitySnapshot(when=_dt(), equity=Decimal("10000"))
+    try:
+        snap.equity = Decimal(0)  # type: ignore[misc]
+        assert False, "Should have raised"
+    except AttributeError:
+        pass
+
+
+# --- TradingLedger basic tests ---
+
+
+def test_ledger_initial_state():
+    ledger = TradingLedger(initial_cash=Decimal("10000"))
+    assert ledger.cash == Decimal("10000")
+    assert ledger.get_equity() == Decimal("10000")
+    assert ledger.get_unrealized_pnl() == Decimal(0)
+    assert len(ledger.trades) == 0
+    assert len(ledger.equity_curve) == 0
+    assert len(ledger.open_positions) == 0
+
+
+def test_ledger_open_position():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    result = ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt())
+    assert result is None  # Opening, no trade record.
+    assert btc_pair in ledger.open_positions
+    assert ledger.open_positions[btc_pair] == Decimal("1")
+
+
+def test_ledger_close_position():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt(1))
+    trade = ledger.record_fill(btc_pair, Decimal("-1"), Decimal("55000"), _dt(2), reason="take_profit")
+    assert trade is not None
+    assert trade.realized_pnl == Decimal("5000")
+    assert trade.return_pct == Decimal("0.1")
+    assert trade.reason == "take_profit"
+    assert trade.entry_price == Decimal("50000")
+    assert trade.exit_price == Decimal("55000")
+    assert len(ledger.trades) == 1
+    assert btc_pair not in ledger.open_positions
+    assert ledger.cash == Decimal("105000")
+
+
+def test_ledger_partial_close():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("2"), Decimal("50000"), _dt(1))
+    trade = ledger.record_fill(btc_pair, Decimal("-1"), Decimal("55000"), _dt(2))
+    assert trade is not None
+    assert trade.realized_pnl == Decimal("5000")
+    assert ledger.open_positions[btc_pair] == Decimal("1")
+
+
+def test_ledger_add_to_position():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt(1))
+    result = ledger.record_fill(btc_pair, Decimal("1"), Decimal("60000"), _dt(2))
+    assert result is None  # Adding, no trade record.
+    assert ledger.open_positions[btc_pair] == Decimal("2")
+
+
+def test_ledger_flip_position():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt(1))
+    trade = ledger.record_fill(btc_pair, Decimal("-2"), Decimal("55000"), _dt(2))
+    assert trade is not None
+    assert trade.realized_pnl == Decimal("5000")
+    # Flipped to short 1.
+    assert ledger.open_positions[btc_pair] == Decimal("-1")
+
+
+def test_ledger_short_position():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("-1"), Decimal("50000"), _dt(1))
+    trade = ledger.record_fill(btc_pair, Decimal("1"), Decimal("45000"), _dt(2))
+    assert trade is not None
+    assert trade.realized_pnl == Decimal("5000")
+    assert btc_pair not in ledger.open_positions
+
+
+def test_ledger_unrealized_pnl():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt())
+    ledger.update_price(btc_pair, Decimal("55000"))
+    assert ledger.get_unrealized_pnl() == Decimal("5000")
+    assert ledger.get_equity() == Decimal("105000")
+
+
+def test_ledger_update_price_no_position():
+    ledger = TradingLedger(initial_cash=Decimal("10000"))
+    # Updating price for a pair with no position should not error.
+    ledger.update_price(btc_pair, Decimal("50000"))
+    assert ledger.get_equity() == Decimal("10000")
+
+
+def test_ledger_multiple_positions():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt())
+    ledger.record_fill(eth_pair, Decimal("10"), Decimal("3000"), _dt())
+    assert len(ledger.open_positions) == 2
+
+
+# --- Equity snapshots ---
+
+
+def test_ledger_take_snapshot():
+    ledger = TradingLedger(initial_cash=Decimal("10000"))
+    snap = ledger.take_snapshot(_dt())
+    assert snap.equity == Decimal("10000")
+    assert snap.when == _dt()
+    assert len(ledger.equity_curve) == 1
+
+
+def test_ledger_auto_snapshot():
+    ledger = TradingLedger(
+        initial_cash=Decimal("100000"),
+        equity_snapshot_interval=datetime.timedelta(hours=1),
+    )
+    # First fill triggers first snapshot.
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt(1, 12, 0))
+    assert len(ledger.equity_curve) == 1
+
+    # Fill within interval does not trigger snapshot.
+    ledger.update_price(btc_pair, Decimal("51000"), _dt(1, 12, 30))
+    assert len(ledger.equity_curve) == 1
+
+    # Fill after interval triggers snapshot.
+    ledger.update_price(btc_pair, Decimal("52000"), _dt(1, 13, 1))
+    assert len(ledger.equity_curve) == 2
+
+
+# --- Daily/weekly summaries ---
+
+
+def test_ledger_daily_pnl():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt(1))
+    ledger.record_fill(btc_pair, Decimal("-1"), Decimal("55000"), _dt(1))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("55000"), _dt(2))
+    ledger.record_fill(btc_pair, Decimal("-1"), Decimal("53000"), _dt(2))
+    daily = ledger.get_daily_pnl()
+    assert daily[datetime.date(2026, 1, 1)] == Decimal("5000")
+    assert daily[datetime.date(2026, 1, 2)] == Decimal("-2000")
+
+
+def test_ledger_weekly_pnl():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt(1))
+    ledger.record_fill(btc_pair, Decimal("-1"), Decimal("55000"), _dt(2))
+    weekly = ledger.get_weekly_pnl()
+    assert len(weekly) == 1
+    pnl = list(weekly.values())[0]
+    assert pnl == Decimal("5000")
+
+
+# --- Metrics calculation ---
+
+
+def test_calculate_max_drawdown_empty():
+    assert calculate_max_drawdown([]) == Decimal(0)
+
+
+def test_calculate_max_drawdown_single():
+    assert calculate_max_drawdown([EquitySnapshot(_dt(), Decimal("10000"))]) == Decimal(0)
+
+
+def test_calculate_max_drawdown():
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("10000")),
+        EquitySnapshot(_dt(2), Decimal("12000")),
+        EquitySnapshot(_dt(3), Decimal("9000")),  # 25% drawdown from 12000.
+        EquitySnapshot(_dt(4), Decimal("11000")),
+    ]
+    dd = calculate_max_drawdown(curve)
+    assert dd == Decimal("0.25")
+
+
+def test_calculate_max_drawdown_no_drawdown():
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("10000")),
+        EquitySnapshot(_dt(2), Decimal("11000")),
+        EquitySnapshot(_dt(3), Decimal("12000")),
+    ]
+    assert calculate_max_drawdown(curve) == Decimal(0)
+
+
+def test_calculate_sharpe_insufficient_data():
+    assert calculate_sharpe_ratio([]) is None
+    assert calculate_sharpe_ratio([EquitySnapshot(_dt(), Decimal("10000"))]) is None
+
+
+def test_calculate_sharpe_ratio():
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("10000")),
+        EquitySnapshot(_dt(2), Decimal("10100")),
+        EquitySnapshot(_dt(3), Decimal("10200")),
+        EquitySnapshot(_dt(4), Decimal("10300")),
+    ]
+    sharpe = calculate_sharpe_ratio(curve)
+    assert sharpe is not None
+    assert sharpe > 0
+
+
+def test_calculate_sharpe_zero_std():
+    # All same equity = zero std dev.
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("10000")),
+        EquitySnapshot(_dt(2), Decimal("10000")),
+        EquitySnapshot(_dt(3), Decimal("10000")),
+    ]
+    assert calculate_sharpe_ratio(curve) is None
+
+
+def test_calculate_sortino_insufficient_data():
+    assert calculate_sortino_ratio([]) is None
+    assert calculate_sortino_ratio([EquitySnapshot(_dt(), Decimal("10000"))]) is None
+
+
+def test_calculate_sortino_no_downside():
+    # All positive returns = no downside.
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("10000")),
+        EquitySnapshot(_dt(2), Decimal("10100")),
+        EquitySnapshot(_dt(3), Decimal("10200")),
+    ]
+    assert calculate_sortino_ratio(curve) is None
+
+
+def test_calculate_sortino_ratio():
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("10000")),
+        EquitySnapshot(_dt(2), Decimal("10100")),
+        EquitySnapshot(_dt(3), Decimal("9900")),
+        EquitySnapshot(_dt(4), Decimal("10200")),
+    ]
+    sortino = calculate_sortino_ratio(curve)
+    assert sortino is not None
+
+
+def test_calculate_metrics_empty():
+    metrics = calculate_metrics([], [])
+    assert metrics.total_trades == 0
+    assert metrics.win_rate == Decimal(0)
+    assert metrics.sharpe_ratio is None
+
+
+def test_calculate_metrics_with_trades():
+    trades = [
+        TradeRecord(
+            trade_id="1", pair=btc_pair, entry_dt=_dt(1), exit_dt=_dt(2),
+            signed_qty=Decimal("1"), entry_price=Decimal("50000"), exit_price=Decimal("55000"),
+            realized_pnl=Decimal("5000"), return_pct=Decimal("0.1"),
+        ),
+        TradeRecord(
+            trade_id="2", pair=btc_pair, entry_dt=_dt(3), exit_dt=_dt(4),
+            signed_qty=Decimal("1"), entry_price=Decimal("55000"), exit_price=Decimal("53000"),
+            realized_pnl=Decimal("-2000"), return_pct=Decimal("-0.0364"),
+        ),
+        TradeRecord(
+            trade_id="3", pair=eth_pair, entry_dt=_dt(5), exit_dt=_dt(6),
+            signed_qty=Decimal("10"), entry_price=Decimal("3000"), exit_price=Decimal("3200"),
+            realized_pnl=Decimal("2000"), return_pct=Decimal("0.0667"),
+        ),
+    ]
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("100000")),
+        EquitySnapshot(_dt(2), Decimal("105000")),
+        EquitySnapshot(_dt(3), Decimal("105000")),
+        EquitySnapshot(_dt(4), Decimal("103000")),
+        EquitySnapshot(_dt(5), Decimal("103000")),
+        EquitySnapshot(_dt(6), Decimal("105000")),
+    ]
+    metrics = calculate_metrics(trades, curve)
+    assert metrics.total_trades == 3
+    assert metrics.winning_trades == 2
+    assert metrics.losing_trades == 1
+    assert metrics.total_pnl == Decimal("5000")
+    assert metrics.profit_factor is not None
+    assert metrics.profit_factor == Decimal("3.5")  # 7000 / 2000.
+    assert metrics.max_drawdown > 0
+    assert metrics.sharpe_ratio is not None
+    assert metrics.calmar_ratio is not None
+
+
+def test_calculate_metrics_all_winners():
+    trades = [
+        TradeRecord(
+            trade_id="1", pair=btc_pair, entry_dt=_dt(1), exit_dt=_dt(2),
+            signed_qty=Decimal("1"), entry_price=Decimal("50000"), exit_price=Decimal("55000"),
+            realized_pnl=Decimal("5000"), return_pct=Decimal("0.1"),
+        ),
+    ]
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("100000")),
+        EquitySnapshot(_dt(2), Decimal("105000")),
+    ]
+    metrics = calculate_metrics(trades, curve)
+    assert metrics.win_rate == Decimal("1")
+    assert metrics.profit_factor is None  # No losses.
+    assert metrics.avg_loss == Decimal(0)
+
+
+def test_calculate_metrics_no_drawdown():
+    trades = [
+        TradeRecord(
+            trade_id="1", pair=btc_pair, entry_dt=_dt(1), exit_dt=_dt(2),
+            signed_qty=Decimal("1"), entry_price=Decimal("50000"), exit_price=Decimal("55000"),
+            realized_pnl=Decimal("5000"), return_pct=Decimal("0.1"),
+        ),
+    ]
+    curve = [
+        EquitySnapshot(_dt(1), Decimal("100000")),
+        EquitySnapshot(_dt(2), Decimal("105000")),
+    ]
+    metrics = calculate_metrics(trades, curve)
+    assert metrics.calmar_ratio is None  # No drawdown.
+
+
+# --- Ledger integrated metrics ---
+
+
+def test_ledger_calculate_metrics():
+    ledger = TradingLedger(initial_cash=Decimal("100000"))
+    ledger.take_snapshot(_dt(1))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("50000"), _dt(1))
+    ledger.record_fill(btc_pair, Decimal("-1"), Decimal("55000"), _dt(2))
+    ledger.take_snapshot(_dt(2))
+    ledger.record_fill(btc_pair, Decimal("1"), Decimal("55000"), _dt(3))
+    ledger.record_fill(btc_pair, Decimal("-1"), Decimal("53000"), _dt(4))
+    ledger.take_snapshot(_dt(4))
+
+    metrics = ledger.calculate_metrics()
+    assert metrics.total_trades == 2
+    assert metrics.winning_trades == 1
+    assert metrics.losing_trades == 1
+    assert metrics.total_pnl == Decimal("3000")
+
+
+# --- PerformanceMetrics frozen ---
+
+
+def test_performance_metrics_frozen():
+    metrics = PerformanceMetrics(
+        total_trades=0, winning_trades=0, losing_trades=0,
+        win_rate=Decimal(0), total_pnl=Decimal(0), avg_pnl=Decimal(0),
+        profit_factor=None, expectancy=Decimal(0), max_drawdown=Decimal(0),
+        sharpe_ratio=None, sortino_ratio=None, calmar_ratio=None,
+        avg_win=Decimal(0), avg_loss=Decimal(0),
+    )
+    try:
+        metrics.total_trades = 1  # type: ignore[misc]
+        assert False, "Should have raised"
+    except AttributeError:
+        pass


### PR DESCRIPTION
## Summary
- Adds `basana.core.ledger` module for paper trading analytics
- `TradingLedger`: records fills, tracks positions, manages equity curve with configurable snapshot intervals
- `TradeRecord`: immutable trade journal entries with entry/exit prices, P&L, return %, and reason codes
- Performance metrics: Sharpe ratio, Sortino ratio, Calmar ratio, max drawdown, profit factor, expectancy, win rate
- Daily and weekly P&L summaries
- 32 tests with 100% coverage

## Test plan
- [x] All 32 new tests pass
- [x] Full existing test suite passes
- [x] 100% coverage maintained
- [x] mypy and ruff pass clean

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)