### PR TITLE
feat: add WalkForwardEngine for evaluation module

### DIFF
--- a/basana/core/evaluation/__init__.py
+++ b/basana/core/evaluation/__init__.py
@@ -16,6 +16,12 @@
 
 # ruff: noqa: F401
 
+from basana.core.evaluation.engine import (
+    FoldOutput,
+    ParamOptimizer,
+    StrategyRunner,
+    WalkForwardEngine,
+)
 from basana.core.evaluation.report import build_report, format_report
 from basana.core.evaluation.types import (
     EvaluationReport,

--- a/basana/core/evaluation/engine.py
+++ b/basana/core/evaluation/engine.py
@@ -1,0 +1,199 @@
+# Basana
+#
+# Copyright 2026 Christian Pojoni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Walk-forward evaluation engine.
+
+Runs a user-supplied strategy factory over train/test window pairs,
+collects per-fold metrics via :class:`TradingLedger`, and produces
+an :class:`EvaluationReport`.
+
+Typical usage::
+
+    from basana.core.evaluation.engine import WalkForwardEngine
+
+    engine = WalkForwardEngine(
+        strategy_name="pid_mean_reversion",
+        bar_source_factory=my_bar_source_factory,
+        strategy_runner=my_strategy_runner,
+        windows=generate_sliding_windows(...),
+        periods_per_year=365 * 24,
+    )
+    report = await engine.run()
+    print(format_report(report))
+"""
+
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+import logging
+
+from basana.core import logs
+from basana.core.evaluation.report import build_report
+from basana.core.evaluation.types import EvaluationReport, FoldResult, WindowSpec
+from basana.core.evaluation.walk_forward import pair_windows
+from basana.core.ledger.types import EquitySnapshot, PerformanceMetrics, TradeRecord
+
+
+logger = logging.getLogger(__name__)
+
+
+class FoldOutput:
+    """Container returned by a strategy runner for a single window.
+
+    :param trades: Completed trade records within the window.
+    :param equity_curve: Equity snapshots within the window.
+    :param metrics: Pre-calculated metrics, or ``None`` to auto-calculate.
+    :param params: Optional dict of parameters used (e.g. tuned hyperparams).
+    """
+
+    def __init__(
+        self,
+        trades: Sequence[TradeRecord],
+        equity_curve: Sequence[EquitySnapshot],
+        metrics: Optional[PerformanceMetrics] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ):
+        self.trades = trades
+        self.equity_curve = equity_curve
+        self.metrics = metrics
+        self.params = params or {}
+
+
+#: Signature for a strategy runner callable.
+#:
+#: Given a :class:`WindowSpec` and optional params dict, it must:
+#:   1. Set up a dispatcher + exchange + strategy for the window period.
+#:   2. Run the backtest.
+#:   3. Return a :class:`FoldOutput` with trades and equity curve.
+#:
+#: The ``params`` argument carries forward the best parameters found
+#: during the training window when running the corresponding test window.
+StrategyRunner = Callable[[WindowSpec, Optional[Dict[str, Any]]], Awaitable[FoldOutput]]
+
+#: Signature for an optional parameter optimizer callable.
+#:
+#: Given training :class:`FoldOutput`, returns the best parameter dict
+#: to use on the test window.  If not provided, the engine runs test
+#: windows with ``params=None``.
+ParamOptimizer = Callable[[WindowSpec, FoldOutput], Awaitable[Dict[str, Any]]]
+
+
+class WalkForwardEngine:
+    """Runs walk-forward evaluation across train/test window pairs.
+
+    :param strategy_name: Name for the evaluation report.
+    :param strategy_runner: Async callable that runs a single window.
+    :param windows: Flat list of alternating train/test :class:`WindowSpec`.
+        Use :func:`generate_sliding_windows` or :func:`generate_expanding_windows`.
+    :param param_optimizer: Optional async callable that extracts best params
+        from a training fold.  If provided, its output is passed to the test runner.
+    :param periods_per_year: Annualization factor for aggregate metrics.
+    """
+
+    def __init__(
+        self,
+        strategy_name: str,
+        strategy_runner: StrategyRunner,
+        windows: Sequence[WindowSpec],
+        param_optimizer: Optional[ParamOptimizer] = None,
+        periods_per_year: int = 252,
+    ):
+        self._strategy_name = strategy_name
+        self._runner = strategy_runner
+        self._folds = pair_windows(list(windows))
+        self._optimizer = param_optimizer
+        self._periods_per_year = periods_per_year
+
+    async def run(self) -> EvaluationReport:
+        """Execute the walk-forward evaluation.
+
+        For each fold:
+          1. Run the strategy on the training window.
+          2. If a ``param_optimizer`` is set, extract best params from training.
+          3. Run the strategy on the test window (with optimized params if available).
+          4. Collect :class:`FoldResult`.
+
+        :returns: An :class:`EvaluationReport` with per-fold and aggregate OOS metrics.
+        """
+        from basana.core.ledger.metrics import calculate_metrics
+
+        fold_results: List[FoldResult] = []
+        all_oos_trades: List[TradeRecord] = []
+        all_oos_equity: List[EquitySnapshot] = []
+
+        for i, (train_window, test_window) in enumerate(self._folds):
+            logger.info(
+                logs.StructuredMessage(
+                    "Running fold",
+                    fold=i,
+                    train=f"{train_window.start.date()} → {train_window.end.date()}",
+                    test=f"{test_window.start.date()} → {test_window.end.date()}",
+                )
+            )
+
+            # 1. Train
+            train_output = await self._runner(train_window, None)
+            train_metrics = train_output.metrics or calculate_metrics(
+                train_output.trades, train_output.equity_curve, self._periods_per_year
+            )
+
+            # 2. Optimize params (optional)
+            test_params: Optional[Dict[str, Any]] = None
+            if self._optimizer is not None:
+                test_params = await self._optimizer(train_window, train_output)
+                logger.info(
+                    logs.StructuredMessage(
+                        "Optimized params for test",
+                        fold=i,
+                        params=str(test_params),
+                    )
+                )
+
+            # 3. Test
+            test_output = await self._runner(test_window, test_params)
+            test_metrics = test_output.metrics or calculate_metrics(
+                test_output.trades, test_output.equity_curve, self._periods_per_year
+            )
+
+            fold_results.append(FoldResult(
+                fold_index=i,
+                train_window=train_window,
+                test_window=test_window,
+                train_metrics=train_metrics,
+                test_metrics=test_metrics,
+            ))
+
+            all_oos_trades.extend(test_output.trades)
+            all_oos_equity.extend(test_output.equity_curve)
+
+            logger.info(
+                logs.StructuredMessage(
+                    "Fold complete",
+                    fold=i,
+                    train_trades=train_metrics.total_trades,
+                    test_trades=test_metrics.total_trades,
+                    test_pnl=str(test_metrics.total_pnl),
+                )
+            )
+
+        # Sort OOS equity curve chronologically for aggregate metrics.
+        all_oos_equity.sort(key=lambda s: s.when)
+
+        return build_report(
+            self._strategy_name,
+            fold_results,
+            all_oos_trades,
+            all_oos_equity,
+            self._periods_per_year,
+        )

--- a/tests/test_walk_forward_engine.py
+++ b/tests/test_walk_forward_engine.py
@@ -1,0 +1,309 @@
+# Basana
+#
+# Copyright 2026 Christian Pojoni
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from decimal import Decimal
+from typing import Any, Dict, Optional
+import datetime
+
+from dateutil import tz
+
+import basana as bs
+from basana.core.evaluation import (
+    FoldOutput,
+    WalkForwardEngine,
+    WindowSpec,
+    format_report,
+    generate_sliding_windows,
+)
+from basana.core.ledger.types import EquitySnapshot, TradeRecord
+
+utc = tz.UTC
+btc_pair = bs.Pair("BTC", "USD")
+
+
+def _dt(day=1, hour=0):
+    return datetime.datetime(2026, 1, day, hour, 0, 0, tzinfo=utc)
+
+
+def _make_trade(entry_day, exit_day, pnl):
+    return TradeRecord(
+        trade_id=f"t{entry_day}-{exit_day}",
+        pair=btc_pair,
+        entry_dt=_dt(entry_day),
+        exit_dt=_dt(exit_day),
+        signed_qty=Decimal("1"),
+        entry_price=Decimal("50000"),
+        exit_price=Decimal("50000") + pnl,
+        realized_pnl=pnl,
+        return_pct=pnl / Decimal("50000"),
+    )
+
+
+def _make_equity(day, equity):
+    return EquitySnapshot(when=_dt(day), equity=equity)
+
+
+# --- Basic engine run ---
+
+
+def test_engine_basic():
+    """Engine runs strategy on train/test, collects fold results and aggregate OOS."""
+
+    async def _test():
+        windows = generate_sliding_windows(
+            start=_dt(1),
+            end=_dt(31),
+            train_duration=datetime.timedelta(days=10),
+            test_duration=datetime.timedelta(days=5),
+        )
+
+        call_log = []
+
+        async def runner(window: WindowSpec, params: Optional[Dict[str, Any]]) -> FoldOutput:
+            call_log.append((window.label, params))
+            trades = [_make_trade(window.start.day, window.end.day, Decimal("100"))]
+            curve = [
+                _make_equity(window.start.day, Decimal("10000")),
+                _make_equity(window.end.day, Decimal("10100")),
+            ]
+            return FoldOutput(trades=trades, equity_curve=curve)
+
+        engine = WalkForwardEngine(
+            strategy_name="test_strat",
+            strategy_runner=runner,
+            windows=windows,
+            periods_per_year=252,
+        )
+        report = await engine.run()
+
+        assert report.strategy_name == "test_strat"
+        assert len(report.folds) > 0
+
+        # Each fold should have called runner twice (train + test).
+        train_calls = [c for c in call_log if c[0] == "train"]
+        test_calls = [c for c in call_log if c[0] == "test"]
+        assert len(train_calls) == len(report.folds)
+        assert len(test_calls) == len(report.folds)
+
+        # Test calls should have params=None (no optimizer).
+        for _, params in test_calls:
+            assert params is None
+
+        # Aggregate OOS should have trades from all test folds.
+        assert report.aggregate_oos_metrics.total_trades == len(report.folds)
+
+    asyncio.run(_test())
+
+
+def test_engine_with_optimizer():
+    """ParamOptimizer output is forwarded to test runner."""
+
+    async def _test():
+        windows = generate_sliding_windows(
+            start=_dt(1),
+            end=_dt(31),
+            train_duration=datetime.timedelta(days=10),
+            test_duration=datetime.timedelta(days=5),
+        )
+
+        received_params = []
+
+        async def runner(window: WindowSpec, params: Optional[Dict[str, Any]]) -> FoldOutput:
+            if window.label == "test":
+                received_params.append(params)
+            trades = [_make_trade(window.start.day, window.end.day, Decimal("50"))]
+            curve = [
+                _make_equity(window.start.day, Decimal("10000")),
+                _make_equity(window.end.day, Decimal("10050")),
+            ]
+            return FoldOutput(trades=trades, equity_curve=curve)
+
+        async def optimizer(window: WindowSpec, output: FoldOutput) -> Dict[str, Any]:
+            return {"ku": 2.0, "tu": 12}
+
+        engine = WalkForwardEngine(
+            strategy_name="opt_strat",
+            strategy_runner=runner,
+            windows=windows,
+            param_optimizer=optimizer,
+        )
+        report = await engine.run()
+
+        # Every test fold should have received the optimized params.
+        assert len(received_params) == len(report.folds)
+        for p in received_params:
+            assert p == {"ku": 2.0, "tu": 12}
+
+    asyncio.run(_test())
+
+
+def test_engine_empty_windows():
+    """No folds when windows are empty."""
+
+    async def _test():
+        engine = WalkForwardEngine(
+            strategy_name="empty",
+            strategy_runner=lambda w, p: None,  # type: ignore
+            windows=[],
+        )
+        report = await engine.run()
+        assert len(report.folds) == 0
+        assert report.aggregate_oos_metrics.total_trades == 0
+
+    asyncio.run(_test())
+
+
+def test_engine_fold_metrics():
+    """Per-fold train and test metrics are populated."""
+
+    async def _test():
+        windows = [
+            WindowSpec(start=_dt(1), end=_dt(11), label="train"),
+            WindowSpec(start=_dt(11), end=_dt(16), label="test"),
+        ]
+
+        async def runner(window: WindowSpec, params: Optional[Dict[str, Any]]) -> FoldOutput:
+            pnl = Decimal("200") if window.label == "train" else Decimal("-50")
+            trades = [_make_trade(window.start.day, window.end.day, pnl)]
+            curve = [
+                _make_equity(window.start.day, Decimal("10000")),
+                _make_equity(window.end.day, Decimal("10000") + pnl),
+            ]
+            return FoldOutput(trades=trades, equity_curve=curve)
+
+        engine = WalkForwardEngine(
+            strategy_name="fold_metrics",
+            strategy_runner=runner,
+            windows=windows,
+        )
+        report = await engine.run()
+
+        assert len(report.folds) == 1
+        fold = report.folds[0]
+        assert fold.train_metrics.total_pnl == Decimal("200")
+        assert fold.test_metrics.total_pnl == Decimal("-50")
+
+    asyncio.run(_test())
+
+
+def test_engine_pre_calculated_metrics():
+    """FoldOutput.metrics is used when provided instead of auto-calculating."""
+
+    async def _test():
+        from basana.core.ledger.types import PerformanceMetrics
+
+        _ZERO = Decimal(0)
+        custom_metrics = PerformanceMetrics(
+            total_trades=99, winning_trades=99, losing_trades=0,
+            win_rate=Decimal("1"), total_pnl=Decimal("9999"), avg_pnl=Decimal("101"),
+            profit_factor=None, expectancy=Decimal("101"), max_drawdown=_ZERO,
+            sharpe_ratio=None, sortino_ratio=None, calmar_ratio=None,
+            avg_win=Decimal("101"), avg_loss=_ZERO,
+        )
+
+        windows = [
+            WindowSpec(start=_dt(1), end=_dt(11), label="train"),
+            WindowSpec(start=_dt(11), end=_dt(16), label="test"),
+        ]
+
+        async def runner(window: WindowSpec, params: Optional[Dict[str, Any]]) -> FoldOutput:
+            return FoldOutput(trades=[], equity_curve=[], metrics=custom_metrics)
+
+        engine = WalkForwardEngine(
+            strategy_name="custom",
+            strategy_runner=runner,
+            windows=windows,
+        )
+        report = await engine.run()
+        # Both train and test should use the pre-calculated metrics.
+        assert report.folds[0].train_metrics.total_trades == 99
+        assert report.folds[0].test_metrics.total_trades == 99
+
+    asyncio.run(_test())
+
+
+def test_engine_report_is_formattable():
+    """Produced report works with format_report."""
+
+    async def _test():
+        windows = [
+            WindowSpec(start=_dt(1), end=_dt(11), label="train"),
+            WindowSpec(start=_dt(11), end=_dt(16), label="test"),
+        ]
+
+        async def runner(window: WindowSpec, params: Optional[Dict[str, Any]]) -> FoldOutput:
+            trades = [_make_trade(window.start.day, window.end.day, Decimal("100"))]
+            curve = [
+                _make_equity(window.start.day, Decimal("10000")),
+                _make_equity(window.end.day, Decimal("10100")),
+            ]
+            return FoldOutput(trades=trades, equity_curve=curve)
+
+        engine = WalkForwardEngine(
+            strategy_name="fmt_test",
+            strategy_runner=runner,
+            windows=windows,
+        )
+        report = await engine.run()
+        text = format_report(report)
+        assert "fmt_test" in text
+        assert "Fold 0" in text
+
+    asyncio.run(_test())
+
+
+def test_engine_oos_equity_sorted():
+    """Aggregate OOS equity curve is chronologically sorted."""
+
+    async def _test():
+        windows = generate_sliding_windows(
+            start=_dt(1),
+            end=_dt(31),
+            train_duration=datetime.timedelta(days=10),
+            test_duration=datetime.timedelta(days=5),
+        )
+
+        async def runner(window: WindowSpec, params: Optional[Dict[str, Any]]) -> FoldOutput:
+            # Intentionally return equity in reverse order.
+            curve = [
+                _make_equity(window.end.day, Decimal("10100")),
+                _make_equity(window.start.day, Decimal("10000")),
+            ]
+            return FoldOutput(trades=[], equity_curve=curve)
+
+        engine = WalkForwardEngine(
+            strategy_name="sort_test",
+            strategy_runner=runner,
+            windows=windows,
+        )
+        report = await engine.run()
+
+        # Verify OOS equity curve used for aggregate metrics is sorted.
+        # (We can't directly inspect it, but the engine sorts before passing
+        # to build_report, so aggregate metrics should calculate without error.)
+        assert report.aggregate_oos_metrics is not None
+
+    asyncio.run(_test())
+
+
+def test_fold_output_params():
+    """FoldOutput stores optional params dict."""
+    fo = FoldOutput(trades=[], equity_curve=[], params={"ku": 1.5})
+    assert fo.params == {"ku": 1.5}
+
+    fo_empty = FoldOutput(trades=[], equity_curve=[])
+    assert fo_empty.params == {}


### PR DESCRIPTION
Add engine that orchestrates walk-forward backtesting across train/test window pairs, with optional parameter optimization between folds.

Closes #22

https://claude.ai/code/session_01Eq5Xtw75vURC5vQYHao4Wq